### PR TITLE
fix: add bnx firmware to discovery image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,8 @@ COPY --from=initramfs-archive /initramfs.xz /initramfs.xz
 FROM scratch AS container
 COPY --from=docker.io/autonomy/ca-certificates:v0.1.0 / /
 COPY --from=docker.io/autonomy/fhs:v0.1.0 / /
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0 /lib/firmware/bnx2 /lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0 /lib/firmware/bnx2x /lib/firmware/bnx2x
 COPY --from=assets /undionly.kpxe /var/lib/arges/tftp/undionly.kpxe
 COPY --from=assets /undionly.kpxe /var/lib/arges/tftp/undionly.kpxe.0
 COPY --from=assets /ipxe.efi /var/lib/arges/tftp/ipxe.efi


### PR DESCRIPTION
This PR will add in the firmware necessary for bnx nics to work properly
in the discovery phase.