### PR TITLE
chore: make serverclasses global

### DIFF
--- a/api/v1alpha1/serverclass_types.go
+++ b/api/v1alpha1/serverclass_types.go
@@ -36,6 +36,7 @@ type ServerClassStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
 
 // ServerClass is the Schema for the serverclasses API
 type ServerClass struct {

--- a/config/crd/bases/metal.arges.dev_serverclasses.yaml
+++ b/config/crd/bases/metal.arges.dev_serverclasses.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: ServerClassList
     plural: serverclasses
     singular: serverclass
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
This PR will make the serverclass CRD a global resource, instead of
namespacing it. Matches what we have for servers.