### PR TITLE
fix: remove 'arges' from api service name

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,7 +34,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: arges-api
+  name: api
   namespace: system
 spec:
   ports:


### PR DESCRIPTION
We shouldn't use 'arges' anywhere in this project.