### PR TITLE
feat: add ready status to environments

### DIFF
--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -37,20 +37,17 @@ type Initrd struct {
 
 // EnvironmentSpec defines the desired state of Environment
 type EnvironmentSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	Kernel Kernel `json:"kernel,omitempty"`
 	Initrd Initrd `json:"initrd,omitempty"`
 }
 
 // EnvironmentStatus defines the observed state of Environment
 type EnvironmentStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	Ready bool `json:"ready"`
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Kernel",type="string",JSONPath=".spec.kernel.url",description="the kernel for the environment"
 // +kubebuilder:printcolumn:name="Initrd",type="string",JSONPath=".spec.initrd.url",description="the initrd for the environment"

--- a/config/crd/bases/metal.arges.dev_environments.yaml
+++ b/config/crd/bases/metal.arges.dev_environments.yaml
@@ -24,7 +24,8 @@ spec:
     plural: environments
     singular: environment
   scope: Cluster
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Environment is the Schema for the environments API
@@ -65,6 +66,11 @@ spec:
           type: object
         status:
           description: EnvironmentStatus defines the observed state of Environment
+          properties:
+            ready:
+              type: boolean
+          required:
+          - ready
           type: object
       type: object
   version: v1alpha1

--- a/controllers/environment_controller.go
+++ b/controllers/environment_controller.go
@@ -110,6 +110,12 @@ func (r *EnvironmentReconciler) reconcile(req ctrl.Request) (ctrl.Result, error)
 
 	l.Info("all assets saved")
 
+	env.Status.Ready = true
+
+	if err := r.Status().Update(ctx, &env); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
This adds a ready field to the environment status struct. An
environment is marked as ready once all assets have been downloaded.